### PR TITLE
rustify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,19 +43,14 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -80,9 +75,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -90,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
@@ -102,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -136,26 +131,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
-name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "dlib"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,9 +147,9 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -205,17 +180,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "getrandom"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,9 +193,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -327,9 +291,9 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -345,31 +309,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom",
- "redox_syscall",
- "thiserror",
 ]
 
 [[package]]
@@ -378,7 +322,7 @@ version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -393,9 +337,32 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.218"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "shlex"
@@ -417,9 +384,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -461,11 +428,36 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.10"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -483,21 +475,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wayland-backend"
@@ -519,7 +505,7 @@ version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66249d3fc69f76fd74c82cc319300faa554e9d865dab1f7cd66cc20db10b280"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "rustix",
  "wayland-backend",
  "wayland-scanner",
@@ -544,7 +530,7 @@ version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd0ade57c4e6e9a8952741325c30bf82f4246885dca8bf561898b86d0c1f58e"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -556,7 +542,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "782e12f6cd923c3c316130d56205ebab53f55d6666b7faddfad36cecaeeb4022"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -584,28 +570,6 @@ dependencies = [
  "log",
  "pkg-config",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
@@ -681,6 +645,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wl-clipboard-rs"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,9 +674,6 @@ dependencies = [
 
 [[package]]
 name = "xdg"
-version = "2.4.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4583db5cbd4c4c0303df2d15af80f0539db703fa1c68802d4cbbd2dd0f88f6"
-dependencies = [
- "dirs",
-]
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,7 +38,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -63,28 +48,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "autocfg"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "backtrace"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets",
+ "windows-sys",
 ]
 
 [[package]]
@@ -98,12 +62,6 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-
-[[package]]
-name = "bytes"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
@@ -166,7 +124,6 @@ version = "1.0.3"
 dependencies = [
  "clap",
  "indexmap",
- "tokio",
  "toml",
  "wayland-clipboard-listener",
  "wl-clipboard-rs",
@@ -227,7 +184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -258,12 +215,6 @@ dependencies = [
  "libc",
  "wasi",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hashbrown"
@@ -316,16 +267,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,26 +285,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
-dependencies = [
- "adler2",
-]
-
-[[package]]
-name = "mio"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,15 +292,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -395,30 +307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall 0.5.8",
- "smallvec",
- "windows-targets",
+ "windows-sys",
 ]
 
 [[package]]
@@ -430,12 +319,6 @@ dependencies = [
  "fixedbitset",
  "indexmap",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pkg-config"
@@ -480,30 +363,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
-dependencies = [
- "bitflags 2.6.0",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "thiserror",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
@@ -515,7 +383,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -523,12 +391,6 @@ name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -543,29 +405,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
-name = "socket2"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "strsim"
@@ -594,7 +437,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -611,35 +454,6 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tokio"
-version = "1.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
-dependencies = [
- "backtrace",
- "bytes",
- "libc",
- "mio",
- "parking_lot",
- "pin-project-lite",
- "signal-hook-registry",
- "socket2",
- "tokio-macros",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -793,15 +607,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,7 @@ version = "1.0.4"
 dependencies = [
  "basic-toml",
  "clap",
+ "indexmap",
  "serde",
  "wayland-clipboard-listener",
  "wl-clipboard-rs",
@@ -203,9 +204,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clapboard"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "clap",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "basic-toml"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "823388e228f614e9558c6804262db37960ec8821856535f5c3f59913140558f8"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,8 +126,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 name = "clapboard"
 version = "1.0.4"
 dependencies = [
+ "basic-toml",
  "clap",
- "toml",
+ "serde",
  "wayland-clipboard-listener",
  "wl-clipboard-rs",
  "xdg",
@@ -356,15 +366,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,40 +425,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "toml"
-version = "0.8.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
 ]
 
 [[package]]
@@ -643,15 +610,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wl-clipboard-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,6 @@ name = "clapboard"
 version = "1.0.3"
 dependencies = [
  "clap",
- "indexmap",
  "toml",
  "wayland-clipboard-listener",
  "wl-clipboard-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-xdg = "2.4.1"
-toml = "0.5.10"
+xdg = "2.5.2"
+toml = { version = "0.8.20", default-features = false, features = ["parse"] }
 wl-clipboard-rs = "0.9.1"
 wayland-clipboard-listener = "0.2.6"
-clap = { version = "4.5.23", features = ["derive"] }
+clap = { version = "4.5.31", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,3 @@ toml = "0.5.10"
 wl-clipboard-rs = "0.9.1"
 wayland-clipboard-listener = "0.2.6"
 clap = { version = "4.5.23", features = ["derive"] }
-indexmap = { version = "2.7.0", features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clapboard"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ wayland-clipboard-listener = "0.2.6"
 clap = { version = "4.5.31", features = ["derive"] }
 basic-toml = "0.1.9"
 serde = { version = "1.0.218", features = ["derive"] }
+indexmap = "2.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 
 [dependencies]
 xdg = "2.5.2"
-toml = { version = "0.8.20", default-features = false, features = ["parse"] }
 wl-clipboard-rs = "0.9.1"
 wayland-clipboard-listener = "0.2.6"
 clap = { version = "4.5.31", features = ["derive"] }
+basic-toml = "0.1.9"
+serde = { version = "1.0.218", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,4 @@ toml = "0.5.10"
 wl-clipboard-rs = "0.9.1"
 wayland-clipboard-listener = "0.2.6"
 clap = { version = "4.5.23", features = ["derive"] }
-tokio = { version = "1.42.0", features = ["full"] }
 indexmap = { version = "2.7.0", features = ["std"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,8 +141,7 @@ fn history(config: &Config, cache_dir: impl AsRef<Path>) -> Res<()> {
         .and_then(|mut child| {
             child.stdin.as_mut().unwrap().write_all(input.as_bytes())?;
             child.wait_with_output()
-        })
-        .expect("Cannot start your launcher, please confirm you have {command_name} installed or configure another one");
+        }).map_err(|e| format!("cannot start your launcher, please confirm you have {command_name} installed or configure another one: {e:?}"))?;
 
     let result = String::from_utf8_lossy(&output.stdout).trim().to_owned();
     if result.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
+use indexmap::IndexMap;
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::BTreeMap,
     fs::{self, File},
     io::{self, Read, Write},
     path::Path,
@@ -89,7 +90,7 @@ fn main() -> Res<()> {
 }
 
 fn history(config: &Config, cache_dir: impl AsRef<Path>) -> Res<()> {
-    let mut data = HashMap::new();
+    let mut data = IndexMap::new();
 
     let mut entries: Vec<_> = fs::read_dir(&cache_dir)?.flatten().collect();
     // Sort entries by file name (ascending order)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,15 @@
 use clap::Parser;
 use indexmap::IndexMap;
-use std::path::Path;
-use std::path::PathBuf;
 use std::{
-    fs,
-    io::{self, Read, Write},
+    fs::{self, File},
+    io::{self, copy, Read, Write},
+    path::{Path, PathBuf},
     process::{Command, Stdio},
-};
-use std::{
-    fs::File,
-    io::copy,
     time::{SystemTime, UNIX_EPOCH},
 };
 use tokio::task;
-use toml::Value;
-use wayland_clipboard_listener::WlClipboardPasteStream;
-use wayland_clipboard_listener::WlListenType;
+use toml::{value::Table, Value};
+use wayland_clipboard_listener::{WlClipboardPasteStream, WlListenType};
 use wl_clipboard_rs::copy::{MimeSource, MimeType, Options, Source};
 use wl_clipboard_rs::paste::{get_contents, ClipboardType, Seat};
 use xdg::BaseDirectories;
@@ -38,177 +32,173 @@ async fn main() {
         .place_config_file("config.toml")
         .expect("cannot create configuration directory");
 
-    let toml_string = fs::read_to_string(config_path).unwrap_or(String::from(""));
+    let toml_string = fs::read_to_string(config_path).unwrap_or_default();
     let value: Value = toml::from_str(&toml_string).unwrap();
 
-    let default_launcher = vec!["tofi", "--fuzzy-match=true", "--prompt-text=clapboard: "];
+    let default_launcher = ["tofi", "--fuzzy-match=true", "--prompt-text=clapboard: "];
 
     let default_launcher_values: Vec<Value> = default_launcher
         .iter()
-        .map(|x| Value::String(x.to_string()))
+        .map(|x| Value::String((*x).to_string()))
         .collect();
     let default_launcher_value = Value::Array(default_launcher_values);
     let launcher = value
         .get("launcher")
-        .unwrap_or_else(|| &default_launcher_value)
+        .unwrap_or(&default_launcher_value)
         .as_array();
 
     let history_size = value
         .get("history_size")
-        .and_then(|v| v.as_integer())
+        .and_then(Value::as_integer)
         .unwrap_or(50) as usize;
 
-    let default_favorites_value = Value::Table(toml::value::Table::new());
+    let default_favorites_value = Value::Table(Table::new());
     let favorites = value
         .get("favorites")
-        .unwrap_or_else(|| &default_favorites_value)
+        .unwrap_or(&default_favorites_value)
         .as_table()
         .unwrap();
 
     let cache_dir = xdg_dirs.get_cache_home();
 
-    match args.record {
-        Some(record) => {
-            println!("Clapboard recording {record}...");
-            let listeners = if record == "primary" {
-                vec!["primary"]
-            } else if record == "clipboard" {
-                vec!["clipboard"]
-            } else if record == "both" {
-                vec!["primary", "clipboard"]
-            } else {
-                vec![]
-            };
+    if let Some(record) = args.record {
+        println!("Clapboard recording {record}...");
+        let listeners = if record == "primary" {
+            vec!["primary"]
+        } else if record == "clipboard" {
+            vec!["clipboard"]
+        } else if record == "both" {
+            vec!["primary", "clipboard"]
+        } else {
+            vec![]
+        };
 
-            // Spawn tasks for each listener
-            let tasks: Vec<_> = listeners
-                .iter()
-                .map(|&paste_type| {
-                    task::spawn(listen_to_clipboard(
-                        paste_type,
-                        cache_dir.clone(),
-                        history_size,
-                    ))
-                })
-                .collect();
+        // Spawn tasks for each listener
+        let tasks: Vec<_> = listeners
+            .iter()
+            .map(|&paste_type| {
+                task::spawn(listen_to_clipboard(
+                    paste_type,
+                    cache_dir.clone(),
+                    history_size,
+                ))
+            })
+            .collect();
 
-            // Await each task individually
-            for task in tasks {
-                let _ = task.await;
-            }
+        // Await each task individually
+        for task in tasks {
+            let _ = task.await;
         }
-        None => {
-            let mut data: IndexMap<String, String> = IndexMap::new();
+    } else {
+        let mut data: IndexMap<String, String> = IndexMap::new();
 
-            let mut entries: Vec<_> = fs::read_dir(&cache_dir)
-                .unwrap() // Handle the Result from read_dir
-                .flatten() // Flatten the Result<Option<DirEntry>> to just DirEntry
-                .collect(); // Collect into a vector of DirEntry
+        let mut entries: Vec<_> = fs::read_dir(&cache_dir)
+            .unwrap() // Handle the Result from read_dir
+            .flatten() // Flatten the Result<Option<DirEntry>> to just DirEntry
+            .collect(); // Collect into a vector of DirEntry
 
-            // Sort entries by file name (ascending order)
-            entries.sort_by(|a, b| b.file_name().cmp(&a.file_name()));
+        // Sort entries by file name (ascending order)
+        entries.sort_by(|a, b| b.file_name().cmp(&a.file_name()));
 
-            // Iterate over sorted entries
-            for entry in entries {
-                if entry.path().is_dir() {
-                    let timestamp = entry.file_name().into_string().unwrap_or_default();
-                    let text_files =
-                        vec!["UTF8_STRING", "TEXT", "text.plain", "text.html", "STRING"];
-                    let mut found_file = false;
-                    let mut content = String::new();
-                    for file_name in text_files {
-                        let textual_representation = entry.path().join(file_name);
+        // Iterate over sorted entries
+        for entry in entries {
+            if entry.path().is_dir() {
+                let timestamp = entry.file_name().into_string().unwrap_or_default();
+                let text_files = vec!["UTF8_STRING", "TEXT", "text.plain", "text.html", "STRING"];
+                let mut found_file = false;
+                let mut content = String::new();
+                for file_name in text_files {
+                    let textual_representation = entry.path().join(file_name);
 
-                        if textual_representation.exists() {
-                            let mut file = File::open(&textual_representation).unwrap();
-                            if file.read_to_string(&mut content).is_ok() {
-                                found_file = true;
-                                break;
-                            }
+                    if textual_representation.exists() {
+                        let mut file = File::open(&textual_representation).unwrap();
+                        if file.read_to_string(&mut content).is_ok() {
+                            found_file = true;
+                            break;
                         }
                     }
-                    if found_file {
-                        data.insert(
-                            content
-                                .trim()
-                                .to_string()
-                                .replace("\n", " ")
-                                .chars()
-                                .take(50) // Avoid long text
-                                .collect(),
-                            timestamp.to_string(),
-                        );
-                    } else {
-                        // If no file was found, proceed with the else logic
-                        println!("No textfile found for: {}", timestamp.to_string());
-                        data.entry(timestamp.to_string())
-                            .or_insert_with(|| timestamp.to_string());
-                    }
+                }
+                if found_file {
+                    data.insert(
+                        content
+                            .trim()
+                            .to_string()
+                            .replace('\n', " ")
+                            .chars()
+                            .take(50) // Avoid long text
+                            .collect(),
+                        timestamp.to_string(),
+                    );
+                } else {
+                    // If no file was found, proceed with the else logic
+                    println!("No textfile found for: {timestamp}");
+                    data.entry(timestamp.to_string())
+                        .or_insert_with(|| timestamp.to_string());
                 }
             }
-            for (key, value) in favorites {
-                data.entry(key.parse().unwrap())
-                    .or_insert_with(|| value.as_str().unwrap().to_string());
-            }
+        }
+        for (key, value) in favorites {
+            data.entry(key.parse().unwrap())
+                .or_insert_with(|| value.as_str().unwrap().to_string());
+        }
 
-            let input = data.keys().cloned().collect::<Vec<_>>().join("\n");
-            let command_name = launcher.unwrap()[0].as_str().unwrap();
-            let mut command = Command::new(command_name);
-            for arg in &launcher.unwrap()[1..] {
-                command.arg(arg.as_str().unwrap());
-            }
+        let input = data.keys().cloned().collect::<Vec<_>>().join("\n");
+        let command_name = launcher.unwrap()[0].as_str().unwrap();
+        let mut command = Command::new(command_name);
+        for arg in &launcher.unwrap()[1..] {
+            command.arg(arg.as_str().unwrap());
+        }
 
-            let output = command
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .spawn()
-                .and_then(|mut child| {
-                    child.stdin.as_mut().unwrap().write_all(input.as_bytes())?;
-                    child.wait_with_output()
-                })
-            .unwrap_or_else(|_| panic!("Cannot start your launcher, please confirm you have {} installed or configure another one", command_name));
+        let output = command
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .and_then(|mut child| {
+                child.stdin.as_mut().unwrap().write_all(input.as_bytes())?;
+                child.wait_with_output()
+            })
+        .unwrap_or_else(|_| panic!("Cannot start your launcher, please confirm you have {command_name} installed or configure another one"));
 
-            let mut result = String::from_utf8_lossy(&output.stdout).into_owned();
-            result.pop(); // Remove trailing new line
-            if result.len() > 0 {
-                let mut opts = Options::new();
-                opts.foreground(true); // We need to keep the process alive for pasting to work
-                if favorites.contains_key(&result) {
-                    opts.copy(
-                        Source::Bytes(
-                            data.get(&result)
-                                .unwrap()
-                                .to_string()
-                                .into_bytes()
-                                .into_boxed_slice(),
-                        ),
-                        MimeType::Autodetect,
-                    )
-                    .expect("Failed to copy to clipboard");
-                } else {
-                    let prefix = data.get(&result).unwrap().as_str();
-                    let sources: Vec<MimeSource> =
-                        fs::read_dir(format!("{}{}", cache_dir.to_str().unwrap(), prefix))
+        let mut result = String::from_utf8_lossy(&output.stdout).into_owned();
+        result.pop(); // Remove trailing new line
+        if !result.is_empty() {
+            let mut opts = Options::new();
+            opts.foreground(true); // We need to keep the process alive for pasting to work
+            if favorites.contains_key(&result) {
+                opts.copy(
+                    Source::Bytes(
+                        data.get(&result)
                             .unwrap()
-                            .flatten()
-                            .filter_map(|entry| {
-                                let path = entry.path();
-                                let mime_type = path
-                                    .file_name()?
-                                    .to_string_lossy()
-                                    .to_string()
-                                    .replacen(".", "/", 1);
-                                fs::read(&path).ok().map(|contents| MimeSource {
-                                    source: Source::Bytes(contents.into()),
-                                    mime_type: MimeType::Specific(mime_type),
-                                })
+                            .to_string()
+                            .into_bytes()
+                            .into_boxed_slice(),
+                    ),
+                    MimeType::Autodetect,
+                )
+                .expect("Failed to copy to clipboard");
+            } else {
+                let prefix = data.get(&result).unwrap().as_str();
+                let sources: Vec<MimeSource> =
+                    fs::read_dir(format!("{}{}", cache_dir.to_str().unwrap(), prefix))
+                        .unwrap()
+                        .flatten()
+                        .filter_map(|entry| {
+                            let path = entry.path();
+                            let mime_type = path
+                                .file_name()?
+                                .to_string_lossy()
+                                .to_string()
+                                .replacen('.', "/", 1);
+                            fs::read(&path).ok().map(|contents| MimeSource {
+                                source: Source::Bytes(contents.into()),
+                                mime_type: MimeType::Specific(mime_type),
                             })
-                            .collect();
+                        })
+                        .collect();
 
-                    if !sources.is_empty() {
-                        opts.copy_multi(sources)
-                            .expect("Failed to copy to clipboard");
-                    }
+                if !sources.is_empty() {
+                    opts.copy_multi(sources)
+                        .expect("Failed to copy to clipboard");
                 }
             }
         }
@@ -239,19 +229,19 @@ async fn listen_to_clipboard(paste_type: &str, cache_dir: PathBuf, history_size:
                 Ok((mut reader, _)) => {
                     let path = format!("{}{}", cache_dir.to_str().unwrap(), timestamp);
                     fs::create_dir_all(Path::new(&path)).unwrap();
-                    let file_path = format!("{}/{}", &path, mime.replace("/", "."));
+                    let file_path = format!("{}/{}", &path, mime.replace('/', "."));
                     match File::create(&file_path) {
                         Ok(mut file) => {
                             if let Err(e) = copy(&mut reader, &mut file) {
-                                eprintln!("Failed to copy content to {}: {}", file_path, e);
+                                eprintln!("Failed to copy content to {file_path}: {e}");
                             }
                         }
                         Err(e) => {
-                            eprintln!("Failed to create file {}: {}", file_path, e);
+                            eprintln!("Failed to create file {file_path}: {e}");
                         }
                     }
                 }
-                Err(err) => eprintln!("Clipboard {paste_type:?} error: {}", err),
+                Err(err) => eprintln!("Clipboard {paste_type:?} error: {err}"),
             }
         }
         clean_history(&cache_dir, history_size).unwrap();
@@ -260,7 +250,7 @@ async fn listen_to_clipboard(paste_type: &str, cache_dir: PathBuf, history_size:
 
 fn clean_history(directory: &Path, max: usize) -> io::Result<()> {
     let mut entries: Vec<_> = fs::read_dir(directory)?
-        .filter_map(|entry| entry.ok()) // Ignore any errors in reading entries
+        .filter_map(Result::ok) // Ignore any errors in reading entries
         .collect();
 
     entries.sort_by(|a, b| b.file_name().cmp(&a.file_name()));


### PR DESCRIPTION
# make code more rusty

- listen to many `clippy::pedantic` lints
- don't use `tokio` for simple, sync thread-spawning
- don't use the whole `toml` crate, use `basic-toml` instead
- use `serde`'s derive feature
- improve code readability

## commits

- **refactor: pedantic clippy fixes**
- **refactor: unasync**
- **refactor: several**
- **refactor: less immediate unwraps**
- **refactor: cosmetics**
- **chore: dependency updates**
- **chore: version bump**
- **refactor: use basic-toml instead of toml with a struct utilizing serde**
